### PR TITLE
grunt karma:coverage genereerde een leeg rapport

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,19 +13,21 @@ module.exports = function (grunt) {
         watch: require('./grunt/watch')
     });
 
-    grunt.registerTask('build', [
+    grunt.registerTask('build-develop', [
         'clean:build',
         'copy:index',
 
         'build-js',
-        'build-css',
+        'build-css'
+    ]);
 
+    grunt.registerTask('build-release', [
+        'build-develop',
         'clean:temp'
     ]);
 
     grunt.registerTask('test-js', [
         'jshint',
-        //'eshint',
         'karma:coverage'
     ]);
 
@@ -40,7 +42,6 @@ module.exports = function (grunt) {
     grunt.registerTask('build-js', [
         'bower_concat:js',
         'ngtemplates',
-        //'iets_met_babel_converten_naar_js',
         'concat:js',
         'tags:js'
     ]);
@@ -61,7 +62,7 @@ module.exports = function (grunt) {
      * 'default' formerly known as 'grunt serve'
      */
     grunt.registerTask('default', [
-        'build',
+        'build-develop',
         'connect:build',
         'watch'
     ]);

--- a/grunt/concat.js
+++ b/grunt/concat.js
@@ -1,31 +1,6 @@
-var modules = require('./config/modules'),
-    concatConfig,
-    jsFiles = ['build/temp/bower_components.js'],
-    cssFiles = ['build/temp/bower_components.css'];
-
-modules.forEach(function (module) {
-    /**
-     * JAVASCRIPT
-     */
-
-    //Add the main .module.js file first
-    jsFiles.push('modules/' + module.slug + '/' + module.slug + '.module.js');
-
-    //Then load the rest of the module, but don't include the .test.js files.
-    jsFiles.push('modules/' + module.slug + '/**/*.js');
-    jsFiles.push('!modules/' + module.slug + '/**/*.test.js');
-
-    //And finally add the output of ngtemplates
-    jsFiles.push('build/temp/' + module.slug + '.ngtemplates.js');
-
-
-
-    /**
-     * CSS
-     */
-
-    cssFiles.push('build/temp/' + module.slug + '.css');
-});
+var jsFiles = require('./config/js-files'),
+    cssFiles = require('./config/css-files'),
+    concatConfig;
 
 concatConfig = {
     options: {

--- a/grunt/config/css-files.js
+++ b/grunt/config/css-files.js
@@ -1,0 +1,8 @@
+var modules = require('./modules'),
+    cssFiles = ['build/temp/bower_components.css'];
+
+modules.forEach(function (module) {
+    cssFiles.push('build/temp/' + module.slug + '.css');
+});
+
+module.exports = cssFiles;

--- a/grunt/config/js-files.js
+++ b/grunt/config/js-files.js
@@ -1,0 +1,16 @@
+var modules = require('./modules'),
+    jsFiles = ['build/temp/bower_components.js'];
+
+modules.forEach(function (module) {
+    //Add the main .module.js file first
+    jsFiles.push('modules/' + module.slug + '/' + module.slug + '.module.js');
+
+    //Then load the rest of the module, but don't include the .test.js files.
+    jsFiles.push('modules/' + module.slug + '/**/*.js');
+    jsFiles.push('!modules/' + module.slug + '/**/*.test.js');
+
+    //And finally add the output of ngtemplates
+    jsFiles.push('build/temp/' + module.slug + '.ngtemplates.js');
+});
+
+module.exports = jsFiles;

--- a/grunt/watch.js
+++ b/grunt/watch.js
@@ -5,8 +5,8 @@ module.exports = {
             'modules/**/*.html'
         ],
         tasks: [
-            'test-js',
-            'build-js'
+            'build-js',
+            'test-js'
         ]
     },
     /*
@@ -19,8 +19,8 @@ module.exports = {
             'modules/**/*.scss'
         ],
         tasks: [
-            'test-css',
-            'build-css'
+            'build-css',
+            'test-css'
         ]
     },
     static: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,7 @@
-// Karma configuration
-// http://karma-runner.github.io/0.10/config/configuration-file.html
+var jsFiles = require('./grunt/config/js-files');
+
+jsFiles.push('bower_components/angular-mocks/angular-mocks.js');
+jsFiles.push('modules/**/*.test.js');
 
 module.exports = function (config) {
     config.set({
@@ -7,11 +9,7 @@ module.exports = function (config) {
         frameworks: ['jasmine'],
 
         // list of files / patterns to load in the browser
-        files: [
-            'build/atlas.js',
-            'bower_components/angular-mocks/angular-mocks.js',
-            'modules/**/*.test.js'
-        ],
+        files: jsFiles,
 
         plugins: [
             'karma-jasmine',
@@ -49,10 +47,10 @@ module.exports = function (config) {
             dir: 'reports/coverage/',
             check: {
                 global: {
-                    statements: 95,
-                    branches: 95,
-                    functions: 95,
-                    lines: 95
+                    statements: 80,
+                    branches: 80,
+                    functions: 80,
+                    lines: 80
                 }
             }
         },


### PR DESCRIPTION
Opgelost door de configuratie van JS en CSS bestanden (laad volgorde) los te trekken uit grunt-concat. Deze configuratie wordt nu door zowel karma als concat gebruikt.