### PR TITLE
[tg-673] Showing a page now hides the straatbeeld

### DIFF
--- a/modules/atlas/services/application-state/redux/reducers/page-reducers.factory.js
+++ b/modules/atlas/services/application-state/redux/reducers/page-reducers.factory.js
@@ -30,7 +30,7 @@
             newState.map.showLayerSelection = false;
             newState.search = null;
             newState.detail = null;
-            newState.staatbeeld = null;
+            newState.straatbeeld = null;
 
             return newState;
         }

--- a/modules/atlas/services/application-state/redux/reducers/page-reducers.factory.test.js
+++ b/modules/atlas/services/application-state/redux/reducers/page-reducers.factory.test.js
@@ -1,25 +1,59 @@
 describe('The pageReducers factory', function () {
     var pageReducers,
-        defaultState;
+        mockedState;
 
     beforeEach(function () {
         angular.mock.module('atlas');
 
         angular.mock.inject(function (_pageReducers_, _DEFAULT_STATE_) {
             pageReducers = _pageReducers_;
-            defaultState = _DEFAULT_STATE_;
+            mockedState = _DEFAULT_STATE_;
         });
     });
 
     describe('SHOW_PAGE', function () {
-        it('sets page name', function () {
-            var output;
+        var output;
 
-            output = pageReducers.SHOW_PAGE(defaultState, 'welcome');
+        it('sets page name', function () {
+            output = pageReducers.SHOW_PAGE(mockedState, 'welcome');
             expect(output.page).toBe('welcome');
 
-            output = pageReducers.SHOW_PAGE(defaultState, 'goodbye');
+            output = pageReducers.SHOW_PAGE(mockedState, 'goodbye');
             expect(output.page).toBe('goodbye');
+        });
+
+        it('removes the highlighted object from the map', function () {
+            mockedState.map.highlight = 'SOME_HIGHLIGHTED_OBJECT';
+            output = pageReducers.SHOW_PAGE(mockedState, 'goodbye');
+
+            expect(output.map.highlight).toBeNull();
+        });
+
+        it('disables the layer selection, search, detail and straatbeeld', function () {
+            mockedState.search = {
+                query: 'SOME_QUERY',
+                location: null
+            };
+
+            mockedState.map.showLayerSelection = true;
+
+            mockedState.detail = {
+                endpoint: 'http://some-endpoint/path/123',
+                isLoading: false
+            };
+
+            mockedState.straatbeeld = {
+                id: 123,
+                camera: 'WHATEVER',
+                isLoading: false
+            };
+
+            output = pageReducers.SHOW_PAGE(mockedState, 'goodbye');
+
+            expect(output.search).toBeNull();
+            expect(output.map.showLayerSelection).toBe(false);
+            expect(output.detail).toBeNull();
+            expect(output.straatbeeld).toBeNull();
         });
     });
 });


### PR DESCRIPTION
The SHOW_PAGE reducer had a spelling issue. Added a fix plus unit tests.