### PR TITLE
[tg-1013] Type addresseerbaar object consistent weergeven 

### DIFF
--- a/modules/search-results/components/search-results/list/list.component.js
+++ b/modules/search-results/components/search-results/list/list.component.js
@@ -17,9 +17,10 @@
         var vm = this;
 
         vm.showSubtype = function (categorySlug, link) {
-            return (categorySlug === 'openbareruimte' && link.subtype !== 'weg') ||
+            return angular.isString(link.subtype) &&
+                ((categorySlug === 'openbareruimte' && link.subtype !== 'weg') ||
                 (categorySlug === 'adres' && link.subtype !== 'verblijfsobject') ||
-                categorySlug === 'gebied';
+                categorySlug === 'gebied');
         };
     }
 })();

--- a/modules/search-results/components/search-results/list/list.component.js
+++ b/modules/search-results/components/search-results/list/list.component.js
@@ -18,6 +18,7 @@
 
         vm.showSubtype = function (categorySlug, link) {
             return (categorySlug === 'openbareruimte' && link.subtype !== 'weg') ||
+                (categorySlug === 'adres' && link.subtype !== 'verblijfsobject') ||
                 categorySlug === 'gebied';
         };
     }

--- a/modules/search-results/components/search-results/list/list.component.test.js
+++ b/modules/search-results/components/search-results/list/list.component.test.js
@@ -178,4 +178,33 @@ describe('The atlas-search-results-list component', function () {
         expect(component.find('li').eq(0).text()).toContain('(buurt)');
         expect(component.find('li').eq(1).text()).toContain('(bouwblok)');
     });
+
+    it('shows the type of adressen, except for verblijfsobjecten', function () {
+        var component,
+            mockedGebiedenCategory = {
+                slug: 'adres',
+                count: 2,
+                results: [
+                    {
+                        label: 'Link #1',
+                        endpoint: 'http://www.example.com/gebied/1/',
+                        subtype: 'verblijfsobject'
+                    }, {
+                        label: 'Link #2',
+                        endpoint: 'http://www.example.com/gebied/2/',
+                        subtype: 'standplaats'
+                    }, {
+                        label: 'Link #3',
+                        endpoint: 'http://www.example.com/gebied/3/',
+                        subtype: 'ligplaats'
+                    }
+                ]
+            };
+
+        component = getComponent(mockedGebiedenCategory);
+
+        expect(component.find('li').eq(0).text()).not.toContain('(verblijfsobject)');
+        expect(component.find('li').eq(1).text()).toContain('(standplaats)');
+        expect(component.find('li').eq(2).text()).toContain('(ligplaats)');
+    });
 });

--- a/modules/search-results/components/search-results/list/list.component.test.js
+++ b/modules/search-results/components/search-results/list/list.component.test.js
@@ -183,7 +183,7 @@ describe('The atlas-search-results-list component', function () {
         var component,
             mockedGebiedenCategory = {
                 slug: 'adres',
-                count: 2,
+                count: 3,
                 results: [
                     {
                         label: 'Link #1',
@@ -206,5 +206,24 @@ describe('The atlas-search-results-list component', function () {
         expect(component.find('li').eq(0).text()).not.toContain('(verblijfsobject)');
         expect(component.find('li').eq(1).text()).toContain('(standplaats)');
         expect(component.find('li').eq(2).text()).toContain('(ligplaats)');
+    });
+
+    it('doesn\'t show the type when the value is null', function () {
+        var component,
+            mockedGebiedenCategory = {
+                slug: 'adres',
+                count: 1,
+                results: [
+                    {
+                        label: 'Link #1',
+                        endpoint: 'http://www.example.com/gebied/1/',
+                        subtype: null
+                    }
+                ]
+            };
+
+        component = getComponent(mockedGebiedenCategory);
+
+        expect(component.find('li').eq(0).text()).not.toContain('()');
     });
 });

--- a/modules/search-results/components/search-results/search-results.component.js
+++ b/modules/search-results/components/search-results/search-results.component.js
@@ -60,7 +60,7 @@
         });
 
         /**
-         * For both SEARCH BY QUERY and GEOSEARCH
+         * For both SEARCH BY QUERY (with and without category) and GEOSEARCH
          */
         function setSearchResults (searchResults) {
             vm.isLoading = false;

--- a/modules/search-results/components/search-results/search-results.component.test.js
+++ b/modules/search-results/components/search-results/search-results.component.test.js
@@ -469,12 +469,12 @@ describe('The atlas-search-results component', function () {
 
                 it('shows the active category as part of the metadata above the category', function () {
                     //The category name is shown in lowercase
-                    expect(removeWhitespace(component.find('p').text())).toBe('11 "adressen" met "Weesperstraat"');
+                    expect(removeWhitespace(component.find('p').text())).toBe('11 adressen met "Weesperstraat"');
 
                     //The number of results have a thousand separator
                     mockedSearchResults[0].count = 1000;
                     component = getComponent('Weesperstraat', null, 'adres');
-                    expect(removeWhitespace(component.find('p').text())).toBe('1.000 "adressen" met "Weesperstraat"');
+                    expect(removeWhitespace(component.find('p').text())).toBe('1.000 adressen met "Weesperstraat"');
                 });
 
                 it('can have a show more link inside the category', function () {
@@ -598,12 +598,14 @@ describe('The atlas-search-results component', function () {
         });
 
         it('shows meta information above the search results', function () {
-            expect(removeWhitespace(component.find('p').text())).toBe('22 resultaten met "51.123, 4.789 (X, Y)"');
+            expect(removeWhitespace(component.find('p').text()))
+                .toBe('22 resultaten met locatie "51.123, 4.789 (X, Y)"');
 
             //Check the thousands separator
             mockedGeosearchResults[1].count = 1012;
             component = getComponent(null, [51.123, 4.789]);
-            expect(removeWhitespace(component.find('p').text())).toBe('1.022 resultaten met "51.123, 4.789 (X, Y)"');
+            expect(removeWhitespace(component.find('p').text()))
+                .toBe('1.022 resultaten met locatie "51.123, 4.789 (X, Y)"');
         });
 
         it('has indenting for certain \'related\' categories', function () {

--- a/modules/search-results/components/search-results/search-results.html
+++ b/modules/search-results/components/search-results/search-results.html
@@ -11,7 +11,7 @@
                     {{vm.numberOfResults === 1 ? 'resultaat' : 'resultaten'}}
                     met
                     <span ng-if="vm.query">"<strong>{{vm.query}}</strong>"</span>
-                    <span ng-if="vm.location">"<strong>{{vm.location | coordinates}}</strong>"</span>
+                    <span ng-if="vm.location">locatie "<strong>{{vm.location | coordinates}}</strong>"</span>
                 </p>
 
                 <div ng-repeat="category in vm.searchResults"
@@ -47,7 +47,7 @@
             <div ng-if="vm.category">
                 <p>
                     {{vm.numberOfResults | number}}
-                    "<strong>{{vm.categoryName | lowercase}}</strong>"
+                    <strong>{{vm.categoryName | lowercase}}</strong>
                     met
                     <span ng-if="vm.query">"<strong>{{vm.query}}</strong>"</span>
                 </p>

--- a/modules/search-results/services/geosearch/geosearch-formatter.factory.js
+++ b/modules/search-results/services/geosearch/geosearch-formatter.factory.js
@@ -44,8 +44,10 @@
                                 var subtype;
 
                                 if (feature.opr_type) {
+                                    //Openbare ruimtes
                                     subtype = feature.opr_type.toLowerCase();
                                 } else if (feature.type.match(/^gebieden\//)) {
+                                    //Gebieden
                                     subtype = feature.type.replace(/^gebieden\//, '');
                                 } else {
                                     subtype = null;

--- a/modules/search-results/services/search/search.factory.js
+++ b/modules/search-results/services/search/search.factory.js
@@ -27,8 +27,15 @@
                 }
             });
 
-            //When all queries are resolved
-            return $q.all(queries).then(searchFormatter.formatCategories);
+            if (angular.isString(categorySlug)) {
+                //A single category
+                return $q.all(queries).then(function (searchResults) {
+                    return [searchFormatter.formatCategory(categorySlug, searchResults[0])];
+                });
+            } else {
+                //All search results
+                return $q.all(queries).then(searchFormatter.formatCategories);
+            }
         }
 
         function loadMore (category) {

--- a/modules/search-results/services/search/search.factory.test.js
+++ b/modules/search-results/services/search/search.factory.test.js
@@ -53,7 +53,10 @@ describe('The search factory', function () {
                 },
                 searchFormatter: {
                     formatCategories: function () {
-                        return 'FAKE_FORMATTED_CATEGORY_RESULTS';
+                        return 'FAKE_FORMATTED_CATEGORIES_RESULTS';
+                    },
+                    formatCategory: function () {
+                        return 'FAKE_FORMATTED_CATEGORY_RESULT';
                     },
                     formatLinks: function (links) {
                         if (links[0] === 'FAKE_LINK_F') {
@@ -99,6 +102,7 @@ describe('The search factory', function () {
 
         spyOn(api, 'getByUri').and.callThrough();
         spyOn(searchFormatter, 'formatCategories').and.callThrough();
+        spyOn(searchFormatter, 'formatCategory').and.callThrough();
         spyOn(searchFormatter, 'formatLinks').and.callThrough();
     });
 
@@ -120,7 +124,7 @@ describe('The search factory', function () {
         expect(searchFormatter.formatCategories).toHaveBeenCalledTimes(1);
         expect(searchFormatter.formatCategories).toHaveBeenCalledWith(['FAKE_RAW_RESULTS', 'FAKE_RAW_RESULTS']);
 
-        expect(searchResults).toBe('FAKE_FORMATTED_CATEGORY_RESULTS');
+        expect(searchResults).toBe('FAKE_FORMATTED_CATEGORIES_RESULTS');
     });
 
     it('can retrieve a single category based on a query', function () {
@@ -137,10 +141,11 @@ describe('The search factory', function () {
         expect(api.getByUri).toHaveBeenCalledWith('path/to/openbare_ruimte/', {q: 'Waterlooplein'});
 
         //The searchFormatter has ben called once
-        expect(searchFormatter.formatCategories).toHaveBeenCalledTimes(1);
-        expect(searchFormatter.formatCategories).toHaveBeenCalledWith(['FAKE_RAW_RESULTS']);
+        expect(searchFormatter.formatCategory).toHaveBeenCalledTimes(1);
+        expect(searchFormatter.formatCategory).toHaveBeenCalledWith('openbare_ruimte', 'FAKE_RAW_RESULTS');
 
-        expect(searchResults).toBe('FAKE_FORMATTED_CATEGORY_RESULTS');
+        //It gets converted to an Array (with one element) to keep the search-results.component consistent
+        expect(searchResults).toEqual(['FAKE_FORMATTED_CATEGORY_RESULT']);
     });
 
     it('has a load more function that returns a new set of search results', function () {


### PR DESCRIPTION
When to show the subtype:
- Openbare ruimte, except 'weg'
- Adres, except 'verblijfsobject',
- Gebied

When not to show the subtype:
- For ligplaatsen on geosearch (click on map) >> it has its own 'Ligplaatsen' header
- For standplaatsen on geosearch (click on map) >> it has its own 'Standplaatsen' header

All other search results >> don't show it.