### PR TITLE
[tg-639] replace url i.v.m. browser history (back knop)

### DIFF
--- a/modules/atlas/services/redux/middleware/state-to-url-middleware.factory.js
+++ b/modules/atlas/services/redux/middleware/state-to-url-middleware.factory.js
@@ -9,10 +9,20 @@
 
     function stateToUrlMiddlewareFactory (stateToUrl, ACTIONS) {
         var ignoreActions = [
-            ACTIONS.URL_CHANGE, //Prevent infinite loops and
-            ACTIONS.FETCH_DETAIL, //don't update the state before asynchronous call are finished
-            ACTIONS.FETCH_STRAATBEELD
-        ];
+                ACTIONS.URL_CHANGE, //Prevent infinite loops
+                ACTIONS.FETCH_DETAIL, //Don't update the state before asynchronous call are finished
+                ACTIONS.FETCH_STRAATBEELD,
+                ACTIONS.SHOW_LAYER_SELECTION, //Ignore state changes that don't update the URL
+                ACTIONS.HIDE_LAYER_SELECTION
+            ],
+            useReplace = [
+                ACTIONS.MAP_SET_BASELAYER, //Replace the URL instead of adding a new entry to the browser history
+                ACTIONS.MAP_ADD_OVERLAY,
+                ACTIONS.MAP_REMOVE_OVERLAY,
+                ACTIONS.MAP_PAN,
+                ACTIONS.MAP_ZOOM,
+                ACTIONS.STRAATBEELD_SET_ORIENTATION
+            ];
 
         return function (store) {
             return function (next) {
@@ -24,7 +34,10 @@
 
                     //Then update the URL
                     if (ignoreActions.indexOf(action.type) === -1) {
-                        stateToUrl.update(store.getState());
+                        stateToUrl.update(
+                            store.getState(),
+                            useReplace.indexOf(action.type) !== -1
+                        );
                     }
 
                     return returnValue;

--- a/modules/atlas/services/redux/middleware/state-to-url-middleware.factory.test.js
+++ b/modules/atlas/services/redux/middleware/state-to-url-middleware.factory.test.js
@@ -12,14 +12,16 @@ describe('The stateToUrlMiddleware factory', function () {
             type: 'FAKE_ACTION',
             payload: {}
         },
-        stateToUrl;
+        stateToUrl,
+        ACTIONS;
 
     beforeEach(function () {
         angular.mock.module('atlas');
 
-        angular.mock.inject(function (_stateToUrlMiddleware_, _stateToUrl_) {
+        angular.mock.inject(function (_stateToUrlMiddleware_, _stateToUrl_, _ACTIONS_) {
             stateToUrlMiddleware = _stateToUrlMiddleware_;
             stateToUrl = _stateToUrl_;
+            ACTIONS = _ACTIONS_;
         });
 
         spyOn(stateToUrl, 'update');
@@ -39,28 +41,84 @@ describe('The stateToUrlMiddleware factory', function () {
     it('and call the stateToUrl service', function () {
         stateToUrlMiddleware(mockedStore)(mockedNext)(mockedAction);
 
-        expect(stateToUrl.update).toHaveBeenCalledWith('FAKE_STATE');
+        expect(stateToUrl.update).toHaveBeenCalledWith('FAKE_STATE', jasmine.anything());
     });
 
-    it('doesn\'t call stateToUrl.update for URL_CHANGE, FETCH_DETAIL and FETCH_STRAATBEELD', function () {
-        ['URL_CHANGE', 'FETCH_DETAIL', 'FETCH_STRAATBEELD'].forEach(function (action) {
+    it('doesn\'t call stateToUrl.update for URL_CHANGE, FETCH_DETAIL, FETCH_STRAATBEELD, SHOW_LAYER_SELECTION and ' +
+        'HIDE_LAYER_SELECTION', function () {
+
+        var actionWithoutUrlUpdate = [
+            ACTIONS.URL_CHANGE,
+            ACTIONS.FETCH_DETAIL,
+            ACTIONS.FETCH_STRAATBEELD,
+            ACTIONS.SHOW_LAYER_SELECTION,
+            ACTIONS.HIDE_LAYER_SELECTION
+        ];
+
+        actionWithoutUrlUpdate.forEach(function (action) {
             stateToUrlMiddleware(mockedStore)(mockedNext)({
                 type: action,
                 payload: {}
             });
 
-            expect(stateToUrl.update).not.toHaveBeenCalledWith('FAKE_STATE');
+            expect(stateToUrl.update).not.toHaveBeenCalledWith('FAKE_STATE', jasmine.anything());
         });
     });
 
     it('does call stateToUrl.update for all other actions', function () {
-        ['SHOW_DETAIL', 'SHOW_STRAATBEELD', 'SHOW_PAGE', 'HIDE_LAYER_SELECTION'].forEach(function (action) {
+        var actionsWithUrlUpdate = [
+            ACTIONS.SHOW_SEARCH_RESULTS_BY_QUERY,
+            ACTIONS.SHOW_SEARCH_RESULTS_BY_CLICK,
+            ACTIONS.SHOW_SEARCH_RESULTS_CATEGORY,
+            ACTIONS.SHOW_DETAIL,
+            ACTIONS.SHOW_STRAATBEELD,
+            ACTIONS.SHOW_PAGE
+        ];
+
+        actionsWithUrlUpdate.forEach(function (action) {
             stateToUrlMiddleware(mockedStore)(mockedNext)({
                 type: action,
                 payload: {}
             });
 
-            expect(stateToUrl.update).toHaveBeenCalledWith('FAKE_STATE');
+            expect(stateToUrl.update).toHaveBeenCalledWith('FAKE_STATE', jasmine.anything());
+        });
+    });
+
+    it('replaces the URL for some actions', function () {
+        var shouldUseReplace = [
+                ACTIONS.MAP_SET_BASELAYER,
+                ACTIONS.MAP_ADD_OVERLAY,
+                ACTIONS.MAP_REMOVE_OVERLAY,
+                ACTIONS.MAP_PAN,
+                ACTIONS.MAP_ZOOM,
+                ACTIONS.STRAATBEELD_SET_ORIENTATION
+            ],
+            shouldNotUseReplace = [
+                ACTIONS.SHOW_SEARCH_RESULTS_BY_QUERY,
+                ACTIONS.SHOW_SEARCH_RESULTS_BY_CLICK,
+                ACTIONS.SHOW_SEARCH_RESULTS_CATEGORY,
+                ACTIONS.SHOW_DETAIL,
+                ACTIONS.SHOW_STRAATBEELD,
+                ACTIONS.SHOW_PAGE
+            ];
+
+        shouldUseReplace.forEach(function (action) {
+            stateToUrlMiddleware(mockedStore)(mockedNext)({
+                type: action,
+                payload: {}
+            });
+
+            expect(stateToUrl.update).toHaveBeenCalledWith('FAKE_STATE', true);
+        });
+
+        shouldNotUseReplace.forEach(function (action) {
+            stateToUrlMiddleware(mockedStore)(mockedNext)({
+                type: action,
+                payload: {}
+            });
+
+            expect(stateToUrl.update).toHaveBeenCalledWith('FAKE_STATE', false);
         });
     });
 });

--- a/modules/atlas/services/routing/state-to-url.factory.js
+++ b/modules/atlas/services/routing/state-to-url.factory.js
@@ -12,7 +12,17 @@
             update: update
         };
 
-        function update (state) {
+        function update (state, useReplace) {
+            var searchParams = getNewSearchParams(state);
+
+            if (useReplace) {
+                $location.replace();
+            }
+
+            $location.search(searchParams);
+        }
+
+        function getNewSearchParams (state) {
             var searchParams = {};
 
             //Search
@@ -59,7 +69,7 @@
                 }
             }
 
-            $location.search(searchParams);
+            return searchParams;
         }
     }
 })();

--- a/modules/atlas/services/routing/state-to-url.factory.test.js
+++ b/modules/atlas/services/routing/state-to-url.factory.test.js
@@ -12,6 +12,7 @@ describe('The stateToUrl factory', function () {
             mockedState = angular.copy(_DEFAULT_STATE_);
         });
 
+        spyOn($location, 'replace');
         spyOn($location, 'search');
     });
 
@@ -23,7 +24,7 @@ describe('The stateToUrl factory', function () {
                 category: null
             };
 
-            stateToUrl.update(mockedState);
+            stateToUrl.update(mockedState, false);
 
             expect($location.search).toHaveBeenCalledWith(jasmine.objectContaining({
                 zoek: 'i_am_a_query'
@@ -37,7 +38,7 @@ describe('The stateToUrl factory', function () {
                 category: null
             };
 
-            stateToUrl.update(mockedState);
+            stateToUrl.update(mockedState, false);
 
             expect($location.search).toHaveBeenCalledWith(jasmine.objectContaining({
                 zoek: '52.123,4.789'
@@ -51,7 +52,7 @@ describe('The stateToUrl factory', function () {
                 category: 'adres'
             };
 
-            stateToUrl.update(mockedState);
+            stateToUrl.update(mockedState, false);
 
             expect($location.search).toHaveBeenCalledWith(jasmine.objectContaining({
                 categorie: 'adres'
@@ -61,7 +62,7 @@ describe('The stateToUrl factory', function () {
         it('can be omitted', function () {
             mockedState.search = null;
 
-            stateToUrl.update(mockedState);
+            stateToUrl.update(mockedState, false);
 
             expect($location.search).not.toHaveBeenCalledWith(jasmine.objectContaining({
                 zoek: jasmine.any(String)
@@ -73,7 +74,7 @@ describe('The stateToUrl factory', function () {
         it('updates the location', function () {
             mockedState.map.viewCenter = [52.789, 4.123];
 
-            stateToUrl.update(mockedState);
+            stateToUrl.update(mockedState, false);
 
             expect($location.search).toHaveBeenCalledWith(jasmine.objectContaining({
                 lat: '52.789',
@@ -84,7 +85,7 @@ describe('The stateToUrl factory', function () {
         it('updates the baseLayer', function () {
             mockedState.map.baseLayer = 'historische_luchtfoto_1825';
 
-            stateToUrl.update(mockedState);
+            stateToUrl.update(mockedState, false);
 
             expect($location.search).toHaveBeenCalledWith(jasmine.objectContaining({
                 basiskaart: 'historische_luchtfoto_1825'
@@ -95,7 +96,7 @@ describe('The stateToUrl factory', function () {
             //No overlays, no parameter
             mockedState.map.overlays = [];
 
-            stateToUrl.update(mockedState);
+            stateToUrl.update(mockedState, false);
 
             expect($location.search).not.toHaveBeenCalledWith(jasmine.objectContaining({
                 lagen: jasmine.any(String)
@@ -104,7 +105,7 @@ describe('The stateToUrl factory', function () {
             //One overlay
             mockedState.map.overlays = ['overlay_x'];
 
-            stateToUrl.update(mockedState);
+            stateToUrl.update(mockedState, false);
 
             expect($location.search).toHaveBeenCalledWith(jasmine.objectContaining({
                 lagen: 'overlay_x'
@@ -113,7 +114,7 @@ describe('The stateToUrl factory', function () {
             //Two overlays
             mockedState.map.overlays = ['overlay_x', 'overlay_y'];
 
-            stateToUrl.update(mockedState);
+            stateToUrl.update(mockedState, false);
 
             expect($location.search).toHaveBeenCalledWith(jasmine.objectContaining({
                 lagen: 'overlay_x,overlay_y'
@@ -123,7 +124,7 @@ describe('The stateToUrl factory', function () {
         it('keeps track of the zoom level', function () {
             mockedState.map.zoom = 8;
 
-            stateToUrl.update(mockedState);
+            stateToUrl.update(mockedState, false);
 
             expect($location.search).toHaveBeenCalledWith(jasmine.objectContaining({
                 zoom: '8'
@@ -133,7 +134,7 @@ describe('The stateToUrl factory', function () {
         it('can contain encoded GeoJSON for highlighting objects', function () {
             mockedState.map.highlight = 'MOCKED_GEOJSON';
 
-            stateToUrl.update(mockedState);
+            stateToUrl.update(mockedState, false);
 
             expect($location.search).toHaveBeenCalledWith(jasmine.objectContaining({
                 selectie: 'MOCKED_GEOJSON'
@@ -144,7 +145,7 @@ describe('The stateToUrl factory', function () {
     describe('Page', function () {
         it('can store the name of the page', function () {
             //No page, no parameter
-            stateToUrl.update(mockedState);
+            stateToUrl.update(mockedState, false);
 
             expect($location.search).not.toHaveBeenCalledWith(jasmine.objectContaining({
                 pagina: jasmine.Any(String)
@@ -154,7 +155,7 @@ describe('The stateToUrl factory', function () {
             //With a page
             mockedState.page = 'welkom';
 
-            stateToUrl.update(mockedState);
+            stateToUrl.update(mockedState, false);
 
             expect($location.search).toHaveBeenCalledWith(jasmine.objectContaining({
                 pagina: 'welkom'
@@ -165,7 +166,7 @@ describe('The stateToUrl factory', function () {
     describe('Detail', function () {
         it('can store the api endpoint of the detail page', function () {
             //No detail, no parameter
-            stateToUrl.update(mockedState);
+            stateToUrl.update(mockedState, false);
 
             expect($location.search).not.toHaveBeenCalledWith(jasmine.objectContaining({
                 detail: jasmine.Any(String)
@@ -177,7 +178,7 @@ describe('The stateToUrl factory', function () {
                 endpoint: 'https://api-acc.datapunt.amsterdam.nl/bag/verblijfsobject/123/'
             };
 
-            stateToUrl.update(mockedState);
+            stateToUrl.update(mockedState, false);
 
             expect($location.search).toHaveBeenCalledWith(jasmine.objectContaining({
                 detail: 'https://api-acc.datapunt.amsterdam.nl/bag/verblijfsobject/123/'
@@ -187,7 +188,7 @@ describe('The stateToUrl factory', function () {
 
     describe('Straatbeeld', function () {
         it('does nothing is there is no active straatbeeld', function () {
-            stateToUrl.update(mockedState);
+            stateToUrl.update(mockedState, false);
 
             expect($location.search).not.toHaveBeenCalledWith(jasmine.objectContaining({
                 id: jasmine.Any(String)
@@ -208,7 +209,7 @@ describe('The stateToUrl factory', function () {
                 }
             };
 
-            stateToUrl.update(mockedState);
+            stateToUrl.update(mockedState, false);
 
             expect($location.search).toHaveBeenCalledWith(jasmine.objectContaining({
                 id: '67890'
@@ -229,7 +230,7 @@ describe('The stateToUrl factory', function () {
                 }
             };
 
-            stateToUrl.update(mockedState);
+            stateToUrl.update(mockedState, false);
 
             expect($location.search).not.toHaveBeenCalledWith(jasmine.objectContaining({
                 id: jasmine.any(String)
@@ -252,7 +253,7 @@ describe('The stateToUrl factory', function () {
                     }
                 };
 
-                stateToUrl.update(mockedState);
+                stateToUrl.update(mockedState, false);
 
                 expect($location.search).not.toHaveBeenCalledWith(jasmine.objectContaining({
                     heading: jasmine.any(String),
@@ -274,7 +275,7 @@ describe('The stateToUrl factory', function () {
                     }
                 };
 
-                stateToUrl.update(mockedState);
+                stateToUrl.update(mockedState, false);
 
                 expect($location.search).toHaveBeenCalledWith(jasmine.objectContaining({
                     heading: '2',
@@ -300,7 +301,7 @@ describe('The stateToUrl factory', function () {
                     }
                 };
 
-                stateToUrl.update(mockedState);
+                stateToUrl.update(mockedState, false);
 
                 expect($location.search).toHaveBeenCalledWith(jasmine.objectContaining({
                     heading: '2',
@@ -309,5 +310,15 @@ describe('The stateToUrl factory', function () {
                 }));
             });
         });
+    });
+
+    it('has the option to replace the URL', function () {
+        //Without replace
+        stateToUrl.update(mockedState, false);
+        expect($location.replace).not.toHaveBeenCalled();
+
+        //With replace
+        stateToUrl.update(mockedState, true);
+        expect($location.replace).toHaveBeenCalled();
     });
 });

--- a/modules/map/services/panning.factory.js
+++ b/modules/map/services/panning.factory.js
@@ -14,7 +14,7 @@
         };
 
         function initialize (leafletMap) {
-            leafletMap.on('moveend', function () {
+            leafletMap.on('dragend', function () {
                 $rootScope.$applyAsync(function () {
                     store.dispatch({
                         type: ACTIONS.MAP_PAN,

--- a/modules/map/services/panning.factory.test.js
+++ b/modules/map/services/panning.factory.test.js
@@ -59,7 +59,7 @@ describe('The panning factory', function () {
     it('listens for Leaflet\'s moveend event, then it fires the MAP_PAN action', function () {
         panning.initialize(mockedLeafletMap);
 
-        expect(mockedLeafletMap.on).toHaveBeenCalledWith('moveend', jasmine.any(Function));
+        expect(mockedLeafletMap.on).toHaveBeenCalledWith('dragend', jasmine.any(Function));
         expect(moveEndCallback).toBeDefined();
 
         //Trigger the moveend callback manually


### PR DESCRIPTION
Sommige Redux actions voegen een nieuwe entry toe aan de historie. Andere actions vervangen de huidige URL.

De werking van deze implementatie staat hier omschreven: https://dokuwiki.datapunt.amsterdam.nl/doku.php?id=start:uispecs:url-replace

Echte specs zijn er nog niet, Rob M. wil dit in actie zien om daarna 'dingen fine-te-tunen'. Dit is naar eigen inzicht zo gemaakt.