### PR TITLE
[tg-1020] switchen naar andere content met zelfde template

### DIFF
--- a/modules/detail/components/api-call/atlas-api-call.component.js
+++ b/modules/detail/components/api-call/atlas-api-call.component.js
@@ -20,19 +20,21 @@
         var vm = this;
 
         $scope.$watch('vm.endpoint', function (endpoint) {
-            if (vm.useBrkObjectExpanded) {
-                endpoint = endpoint.replace('brk/object', 'brk/object-expand');
+            if (endpoint) {
+                if (vm.useBrkObjectExpanded) {
+                    endpoint = endpoint.replace('brk/object', 'brk/object-expand');
+                }
+
+                vm.apiData = {};
+
+                //Load the first page
+                loadData(endpoint);
+
+                //Load pages 2-n
+                vm.loadMore = function () {
+                    loadData(vm.apiData.next);
+                };
             }
-
-            vm.apiData = {};
-
-            //Load the first page
-            loadData(endpoint);
-
-            //Load pages 2-n
-            vm.loadMore = function () {
-                loadData(vm.apiData.next);
-            };
         });
 
         function loadData (endpoint) {

--- a/modules/detail/components/api-call/atlas-api-call.component.js
+++ b/modules/detail/components/api-call/atlas-api-call.component.js
@@ -14,17 +14,14 @@
             controllerAs: 'vm'
         });
 
-    AtlasApiCallController.$inject = ['api'];
+    AtlasApiCallController.$inject = ['$scope', 'api'];
 
-    function AtlasApiCallController (api) {
-        var vm = this,
-            endpoint;
+    function AtlasApiCallController ($scope, api) {
+        var vm = this;
 
-        if (vm.endpoint) {
-            endpoint = vm.endpoint;
-
+        $scope.$watch('vm.endpoint', function (endpoint) {
             if (vm.useBrkObjectExpanded) {
-                endpoint = vm.endpoint.replace('brk/object', 'brk/object-expand');
+                endpoint = endpoint.replace('brk/object', 'brk/object-expand');
             }
 
             vm.apiData = {};
@@ -36,7 +33,7 @@
             vm.loadMore = function () {
                 loadData(vm.apiData.next);
             };
-        }
+        });
 
         function loadData (endpoint) {
             api.getByUrl(endpoint).then(function (response) {

--- a/modules/detail/components/stelselpedia/header/stelselpedia-header.directive.js
+++ b/modules/detail/components/stelselpedia/header/stelselpedia-header.directive.js
@@ -30,7 +30,6 @@
             isVisible = {};
 
         $scope.$watch('vm.heading', function (heading) {
-            console.log(heading);
             vm.htmlHeading = $sce.trustAsHtml(heading);
         });
 

--- a/modules/detail/components/stelselpedia/header/stelselpedia-header.directive.js
+++ b/modules/detail/components/stelselpedia/header/stelselpedia-header.directive.js
@@ -23,13 +23,16 @@
         };
     }
 
-    AtlasStelselpediaHeaderController.$inject = ['$sce', 'STELSELPEDIA'];
+    AtlasStelselpediaHeaderController.$inject = ['$scope', '$sce', 'STELSELPEDIA'];
 
-    function AtlasStelselpediaHeaderController ($sce, STELSELPEDIA) {
+    function AtlasStelselpediaHeaderController ($scope, $sce, STELSELPEDIA) {
         var vm = this,
             isVisible = {};
 
-        vm.htmlHeading = $sce.trustAsHtml(vm.heading);
+        $scope.$watch('vm.heading', function (heading) {
+            console.log(heading);
+            vm.htmlHeading = $sce.trustAsHtml(heading);
+        });
 
         vm.stelselpedia = STELSELPEDIA.DEFINITIONS[vm.definition];
         vm.stelselpedia.label = vm.usePlural ? vm.stelselpedia.label_plural : vm.stelselpedia.label_singular;


### PR DESCRIPTION
Er waren 2 problemen:

- ng-bind-html binnen stelselpedia-header verliest de binding met de bron data >> watch toegevoegd.
- atlas-partial-select kijkt of de endpoint scope variabele veranderd