### PR TITLE
[tg-1214] autocomplete uitlijning

### DIFF
--- a/modules/header/components/search/autocomplete/_autocomplete.scss
+++ b/modules/header/components/search/autocomplete/_autocomplete.scss
@@ -3,8 +3,8 @@ $suggestion-offset: $base-font-size;
 .c-autocomplete {
   position: absolute;
   top: $search-form-height + $base-whitespace;
-  right: $base-whitespace - 1;
-  left: $base-whitespace - 1;
+  right: -1px;
+  left: -1px;
   border-width: 0 1px 1px;
   border-style: solid;
   border-color: $secondary-gray60;


### PR DESCRIPTION
Er was een issue met de uitlijning van de suggesties. Veroorzaakt door het verwijderen van de default padding bij de grid kolommen.