### PR TITLE
slightly wider print version

### DIFF
--- a/modules/shared/styles/base/_reset-print.scss
+++ b/modules/shared/styles/base/_reset-print.scss
@@ -4,7 +4,7 @@ body {
 }
 
 body {
-  width: 600px;
+  width: 660px;
   margin-right: auto;
   margin-left: auto;
 }


### PR DESCRIPTION
De status bar bij straatbeeld werd niet goed geprint. Oplossing is simpeler dan gedacht; gewoon de hele print versie breder maken. A4 printen past nog steeds.