### PR TITLE
[tg-1268] Removed a redundant call to MAP_FULLSCREEN

### DIFF
--- a/modules/search-results/components/search-results/search-results.component.js
+++ b/modules/search-results/components/search-results/search-results.component.js
@@ -14,9 +14,9 @@
             controllerAs: 'vm'
         });
 
-    AtlasSearchResultsController.$inject = ['$scope', 'SEARCH_CONFIG', 'search', 'geosearch', 'store', 'ACTIONS'];
+    AtlasSearchResultsController.$inject = ['$scope', 'SEARCH_CONFIG', 'search', 'geosearch'];
 
-    function AtlasSearchResultsController ($scope, SEARCH_CONFIG, search, geosearch, store, ACTIONS) {
+    function AtlasSearchResultsController ($scope, SEARCH_CONFIG, search, geosearch) {
         var vm = this;
 
         /**
@@ -56,11 +56,6 @@
                 vm.isLoading = true;
 
                 geosearch.search(location).then(setSearchResults);
-
-                store.dispatch({
-                    type: ACTIONS.MAP_FULLSCREEN,
-                    payload: false
-                });
             }
         });
 


### PR DESCRIPTION
Showing search results already disables the fullscreen mode as part of the search reducers.