### PR TITLE
Coordinaten formateren

### DIFF
--- a/modules/shared/components/coordinates/coordinates.filter.js
+++ b/modules/shared/components/coordinates/coordinates.filter.js
@@ -15,13 +15,18 @@
          */
         return function (wgs84Location) {
             var rdLocation = crsConverter.wgs84ToRd(wgs84Location),
+                formattedRdLocation,
                 formattedWgs84Location;
 
             formattedWgs84Location = wgs84Location.map(function (coordinate) {
-                return coordinate.toFixed('7');
+                return coordinate.toFixed(7);
             }).join(', ');
 
-            return rdLocation.join(', ') + ' (' + formattedWgs84Location + ')';
+            formattedRdLocation = rdLocation.map(function (coordinate) {
+                return coordinate.toFixed(2);
+            }).join(', ');
+
+            return formattedRdLocation + ' (' + formattedWgs84Location + ')';
         };
     }
 })();

--- a/modules/shared/components/coordinates/coordinates.filter.js
+++ b/modules/shared/components/coordinates/coordinates.filter.js
@@ -18,7 +18,7 @@
                 formattedWgs84Location;
 
             formattedWgs84Location = wgs84Location.map(function (coordinate) {
-                return coordinate.toFixed('6');
+                return coordinate.toFixed('7');
             }).join(', ');
 
             return rdLocation.join(', ') + ' (' + formattedWgs84Location + ')';

--- a/modules/shared/components/coordinates/coordinates.filter.test.js
+++ b/modules/shared/components/coordinates/coordinates.filter.test.js
@@ -19,10 +19,10 @@ describe('The coordinates filter', function () {
     });
 
     it('returns a string with the RD and latitude/longitude coordinates', function () {
-        expect(coordinates([52.123456, 4.456789])).toBe('123456, 654123 (52.123456, 4.456789)');
+        expect(coordinates([52.123456, 4.456789])).toBe('123456, 654123 (52.1234560, 4.4567890)');
     });
 
-    it('rounds latitude and longitude down to 6 decimals', function () {
-        expect(coordinates([52.1234565, 4.4567894])).toBe('123456, 654123 (52.123457, 4.456789)');
+    it('rounds latitude and longitude down to 7 decimals', function () {
+        expect(coordinates([52.1234565, 4.4567894])).toBe('123456, 654123 (52.1234565, 4.4567894)');
     });
 });

--- a/modules/shared/components/coordinates/coordinates.filter.test.js
+++ b/modules/shared/components/coordinates/coordinates.filter.test.js
@@ -19,10 +19,10 @@ describe('The coordinates filter', function () {
     });
 
     it('returns a string with the RD and latitude/longitude coordinates', function () {
-        expect(coordinates([52.123456, 4.456789])).toBe('123456, 654123 (52.1234560, 4.4567890)');
+        expect(coordinates([52.123456, 4.456789])).toBe('123456.00, 654123.00 (52.1234560, 4.4567890)');
     });
 
     it('rounds latitude and longitude down to 7 decimals', function () {
-        expect(coordinates([52.1234565, 4.4567894])).toBe('123456, 654123 (52.1234565, 4.4567894)');
+        expect(coordinates([52.1234565246, 4.4567894123])).toBe('123456.00, 654123.00 (52.1234565, 4.4567894)');
     });
 });

--- a/modules/shared/services/crs/crs-converter.factory.js
+++ b/modules/shared/services/crs/crs-converter.factory.js
@@ -22,7 +22,7 @@
         function wgs84ToRd (wgs84Coordinates){
             var rd = proj4(CRS_CONFIG.RD.projection, angular.copy(wgs84Coordinates).reverse());
 
-            return [rd[0].toFixed(2), rd[1].toFixed(2)];
+            return [Number(rd[0].toFixed(2)), Number(rd[1].toFixed(2))];
         }
 
         /*
@@ -33,7 +33,7 @@
         function rdToWgs84 (rdCoordinates){
             var wgs84 = proj4(CRS_CONFIG.RD.projection, CRS_CONFIG.WGS84.projection, rdCoordinates).reverse();
 
-            return [wgs84[0].toFixed(7), wgs84[1].toFixed(7)];
+            return [Number(wgs84[0].toFixed(7)), Number(wgs84[1].toFixed(7))];
         }
     }
 })();

--- a/modules/shared/services/crs/crs-converter.factory.js
+++ b/modules/shared/services/crs/crs-converter.factory.js
@@ -22,7 +22,7 @@
         function wgs84ToRd (wgs84Coordinates){
             var rd = proj4(CRS_CONFIG.RD.projection, angular.copy(wgs84Coordinates).reverse());
 
-            return [Math.round(rd[0]), Math.round(rd[1])];
+            return [rd[0].toFixed(2), rd[1].toFixed(2)];
         }
 
         /*
@@ -31,7 +31,9 @@
          * @returns {Array} wgs84 - An An array with this structure: [lat, lon]
          */
         function rdToWgs84 (rdCoordinates){
-            return proj4(CRS_CONFIG.RD.projection, CRS_CONFIG.WGS84.projection, rdCoordinates).reverse();
+            var wgs84 = proj4(CRS_CONFIG.RD.projection, CRS_CONFIG.WGS84.projection, rdCoordinates).reverse();
+
+            return [wgs84[0].toFixed(7), wgs84[1].toFixed(7)];
         }
     }
 })();

--- a/modules/shared/services/crs/crs-converter.factory.js
+++ b/modules/shared/services/crs/crs-converter.factory.js
@@ -20,9 +20,9 @@
          * @returns {Array} - RD - An array with this structure: [x, y]
          */
         function wgs84ToRd (wgs84Coordinates){
-            var rd = proj4(CRS_CONFIG.RD.projection, angular.copy(wgs84Coordinates).reverse());
+            return proj4(CRS_CONFIG.RD.projection, angular.copy(wgs84Coordinates).reverse());
 
-            return [Number(rd[0].toFixed(2)), Number(rd[1].toFixed(2))];
+            //return [Math.round(rd[0]), Math.round(rd[1])];
         }
 
         /*
@@ -31,9 +31,7 @@
          * @returns {Array} wgs84 - An An array with this structure: [lat, lon]
          */
         function rdToWgs84 (rdCoordinates){
-            var wgs84 = proj4(CRS_CONFIG.RD.projection, CRS_CONFIG.WGS84.projection, rdCoordinates).reverse();
-
-            return [Number(wgs84[0].toFixed(7)), Number(wgs84[1].toFixed(7))];
+            return proj4(CRS_CONFIG.RD.projection, CRS_CONFIG.WGS84.projection, rdCoordinates).reverse();
         }
     }
 })();

--- a/modules/shared/services/crs/crs-converter.factory.test.js
+++ b/modules/shared/services/crs/crs-converter.factory.test.js
@@ -18,8 +18,8 @@ describe('The crsConverter factory', function () {
         expect(output.length).toBe(2);
         expect(angular.isNumber(output[0])).toBe(true);
         expect(angular.isNumber(output[1])).toBe(true);
-        expect(output[0]).toBe(121356);
-        expect(output[1]).toBe(487342);
+        expect(output[0]).toBe(121356.30);
+        expect(output[1]).toBe(487342.36);
 
         //Weesperstraat 113
         output = crsConverter.wgs84ToRd([52.362922, 4.907101]);
@@ -27,8 +27,8 @@ describe('The crsConverter factory', function () {
         expect(output.length).toBe(2);
         expect(angular.isNumber(output[0])).toBe(true);
         expect(angular.isNumber(output[1])).toBe(true);
-        expect(output[0]).toBe(122298);
-        expect(output[1]).toBe(486223);
+        expect(output[0]).toBe(122297.75);
+        expect(output[1]).toBe(486223.01);
     });
 
     it('coverts an rd array to an array with wgs84 coordinates', function () {
@@ -40,8 +40,8 @@ describe('The crsConverter factory', function () {
         expect(output.length).toBe(2);
         expect(angular.isNumber(output[0])).toBe(true);
         expect(angular.isNumber(output[1])).toBe(true);
-        expect(output[0].toFixed(4)).toBe('52.3729');
-        expect(output[1].toFixed(4)).toBe('4.8936');
+        expect(output[0]).toBe(52.3728607);
+        expect(output[1]).toBe(4.8936049);
 
         //Weesperstraat 113
         output = crsConverter.rdToWgs84([122295, 486219]);
@@ -49,7 +49,7 @@ describe('The crsConverter factory', function () {
         expect(output.length).toBe(2);
         expect(angular.isNumber(output[0])).toBe(true);
         expect(angular.isNumber(output[1])).toBe(true);
-        expect(output[0].toFixed(4)).toBe('52.3629');
-        expect(output[1].toFixed(4)).toBe('4.9071');
+        expect(output[0]).toBe(52.3628858);
+        expect(output[1]).toBe(4.9070611);
     });
 });

--- a/modules/shared/services/crs/crs-converter.factory.test.js
+++ b/modules/shared/services/crs/crs-converter.factory.test.js
@@ -18,8 +18,8 @@ describe('The crsConverter factory', function () {
         expect(output.length).toBe(2);
         expect(angular.isNumber(output[0])).toBe(true);
         expect(angular.isNumber(output[1])).toBe(true);
-        expect(output[0]).toBe(121356.30);
-        expect(output[1]).toBe(487342.36);
+        expect(output[0].toFixed(2)).toBe('121356.30');
+        expect(output[1].toFixed(2)).toBe('487342.36');
 
         //Weesperstraat 113
         output = crsConverter.wgs84ToRd([52.362922, 4.907101]);
@@ -27,8 +27,8 @@ describe('The crsConverter factory', function () {
         expect(output.length).toBe(2);
         expect(angular.isNumber(output[0])).toBe(true);
         expect(angular.isNumber(output[1])).toBe(true);
-        expect(output[0]).toBe(122297.75);
-        expect(output[1]).toBe(486223.01);
+        expect(output[0].toFixed(2)).toBe('122297.75');
+        expect(output[1].toFixed(2)).toBe('486223.01');
     });
 
     it('coverts an rd array to an array with wgs84 coordinates', function () {
@@ -40,8 +40,8 @@ describe('The crsConverter factory', function () {
         expect(output.length).toBe(2);
         expect(angular.isNumber(output[0])).toBe(true);
         expect(angular.isNumber(output[1])).toBe(true);
-        expect(output[0]).toBe(52.3728607);
-        expect(output[1]).toBe(4.8936049);
+        expect(output[0].toFixed(7)).toBe('52.3728607');
+        expect(output[1].toFixed(7)).toBe('4.8936049');
 
         //Weesperstraat 113
         output = crsConverter.rdToWgs84([122295, 486219]);
@@ -49,7 +49,7 @@ describe('The crsConverter factory', function () {
         expect(output.length).toBe(2);
         expect(angular.isNumber(output[0])).toBe(true);
         expect(angular.isNumber(output[1])).toBe(true);
-        expect(output[0]).toBe(52.3628858);
-        expect(output[1]).toBe(4.9070611);
+        expect(output[0].toFixed(7)).toBe('52.3628858');
+        expect(output[1].toFixed(7)).toBe('4.9070611');
     });
 });


### PR DESCRIPTION
bij zoekresultaten via klikken op de kaart en onder de panorama viewer worden de coordinaten afgerond op 7 decimalen voor wgs84 en 2 decimalen voor rd komt neer op nauwkeurigheid van centimeters