### PR TITLE
[tg-1465] Disappearing overlays

### DIFF
--- a/modules/map/components/map/map.directive.js
+++ b/modules/map/components/map/map.directive.js
@@ -131,6 +131,7 @@
             if (angular.equals(newOverlays, oldOverlays)) {
                 oldOverlays = [];
             }
+
             return getDiffFromOverlays(newOverlays, oldOverlays);
         }
 

--- a/modules/map/services/layers.factory.js
+++ b/modules/map/services/layers.factory.js
@@ -8,8 +8,7 @@
         layersFactory.$inject = ['L', 'mapConfig', 'BASE_LAYERS', 'OVERLAYS'];
 
     function layersFactory (L, mapConfig, BASE_LAYERS, OVERLAYS) {
-        var baseLayer,
-            wmsLayers = {};
+        var baseLayer;
 
         return {
             setBaseLayer: setBaseLayer,
@@ -61,25 +60,23 @@
         }
 
         function getSubLayers (overlayName) {
-            var wmsUrl,
+            var wmsLayers = [],
+                wmsUrl,
                 wmsSource;
 
-            if (angular.isUndefined(wmsLayers[overlayName])) {
-                wmsLayers[overlayName] = [];
-                wmsUrl = OVERLAYS.SOURCES[overlayName].url;
+            wmsUrl = OVERLAYS.SOURCES[overlayName].url;
 
-                if (!OVERLAYS.SOURCES[overlayName].external) {
-                    wmsUrl = mapConfig.OVERLAY_ROOT + wmsUrl;
-                }
-
-                wmsSource = L.WMS.source(wmsUrl, mapConfig.OVERLAY_OPTIONS);
-
-                OVERLAYS.SOURCES[overlayName].layers.forEach(function (layerName) {
-                    wmsLayers[overlayName].push(wmsSource.getLayer(layerName));
-                });
+            if (!OVERLAYS.SOURCES[overlayName].external) {
+                wmsUrl = mapConfig.OVERLAY_ROOT + wmsUrl;
             }
 
-            return wmsLayers[overlayName];
+            wmsSource = L.WMS.source(wmsUrl, mapConfig.OVERLAY_OPTIONS);
+
+            OVERLAYS.SOURCES[overlayName].layers.forEach(function (layerName) {
+                wmsLayers.push(wmsSource.getLayer(layerName));
+            });
+
+            return wmsLayers;
         }
     }
 })();

--- a/modules/map/services/layers.factory.test.js
+++ b/modules/map/services/layers.factory.test.js
@@ -187,16 +187,5 @@ describe('The layers factory', function () {
             expect(mockedLeafletMap.removeLayer).toHaveBeenCalledWith('FAKE_SUBLAYER_1');
             expect(mockedLeafletMap.removeLayer).toHaveBeenCalledWith('FAKE_SUBLAYER_2');
         });
-
-        it('caches the result of L.WMS.source', function () {
-            expect(L.WMS.source).not.toHaveBeenCalled();
-
-            layers.addOverlay(mockedLeafletMap, 'overlay_a');
-            expect(L.WMS.source).toHaveBeenCalledTimes(1);
-
-            layers.removeOverlay(mockedLeafletMap, 'overlay_a');
-            layers.addOverlay(mockedLeafletMap, 'overlay_a');
-            expect(L.WMS.source).toHaveBeenCalledTimes(1);
-        });
     });
 });


### PR DESCRIPTION
When navigating to the print version of a page or data selection (e.g. pages without a map) and then going back to a page with a map: all overlays are gone.

This is caused by our caching mechanism, we cache the result of sublayers from L.WMS.Source. When the map is drawn again it creates a new L.Map instance and the caching used is tied to a L.Map instance.

Ik wil had gebruik kunnen maken van een interne Leaflet variabele (_leaflet_id) om zo te cachen per instance. Maar ik blijf liever van die interne variabelen af. Zelf een instance ID maken en bijhouden in onze application state vind ik overkill.

P.S. Deze oplossing met caching heb ik ooit gemaakt voor de huidige atlas_client. Daar werkte het wel omdat de kaart daar altijd in de DOM blijft. Aan het begin van dit jaar hadden we deze caching ook niet.