### PR TITLE
[tg-1493] Mocha: only report errors

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -41,6 +41,10 @@ module.exports = function (config) {
             'modules/**/!(*.test).js': ['coverage']
         },
 
+        mochaReporter: {
+            output: 'minimal'
+        },
+
         // optionally, configure the reporter
         // type can also be 'cobertura' which should be understand by Jenkins
         coverageReporter: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,7 +7,9 @@ module.exports = function (config) {
     config.set({
         frameworks: ['jasmine-jquery', 'jasmine'],
         files: jsFiles,
-
+        exclude : [
+            'modules/**/piwik/piwik.run.js'
+        ],
         plugins: [
             'karma-jasmine-jquery',
             'karma-jasmine',
@@ -16,11 +18,8 @@ module.exports = function (config) {
             'karma-phantomjs-launcher'
         ],
         // possible values: OFF, ERROR, WARN, INFO, DEBUG
-        logLevel: 'DEBUG',
+        logLevel: 'ERROR',
         preprocessors: {
-            // source files, that you wanna generate coverage for
-            // do not include tests or libraries
-            // (these files will be instrumented by Istanbul)
             'modules/**/!(*.test).js': ['coverage']
         },
         mochaReporter: {
@@ -38,6 +37,7 @@ module.exports = function (config) {
                 }
             }
         },
-        browsers: ['PhantomJS']
+        browsers: ['PhantomJS'],
+        singleRun: true
     });
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,10 +5,7 @@ jsFiles.push('modules/**/*.test.js');
 
 module.exports = function (config) {
     config.set({
-        // testing framework to use (jasmine/mocha/qunit/...)
         frameworks: ['jasmine-jquery', 'jasmine'],
-
-        // list of files / patterns to load in the browser
         files: jsFiles,
 
         plugins: [
@@ -18,35 +15,17 @@ module.exports = function (config) {
             'karma-coverage',
             'karma-phantomjs-launcher'
         ],
-
-        // level of logging
         // possible values: OFF, ERROR, WARN, INFO, DEBUG
-        logLevel: 'ERROR',
-
-        // enable / disable watching file and executing tests whenever any file changes
-        autoWatch: false,
-
-        // Reporters
-        // - dots
-        // - progress
-        // - junit
-        // - growl
-        // - coverage
-        reporters: ['coverage'],
-
+        logLevel: 'DEBUG',
         preprocessors: {
             // source files, that you wanna generate coverage for
             // do not include tests or libraries
             // (these files will be instrumented by Istanbul)
             'modules/**/!(*.test).js': ['coverage']
         },
-
         mochaReporter: {
             output: 'minimal'
         },
-
-        // optionally, configure the reporter
-        // type can also be 'cobertura' which should be understand by Jenkins
         coverageReporter: {
             type: 'html',
             dir: 'reports/coverage/',
@@ -59,19 +38,6 @@ module.exports = function (config) {
                 }
             }
         },
-
-        // Start these browsers, currently available:
-        // - Chrome
-        // - ChromeCanary
-        // - Firefox
-        // - Opera
-        // - Safari (only Mac)
-        // - PhantomJS
-        // - IE (only Windows)
-        browsers: ['PhantomJS'],
-
-        // Continuous Integration mode
-        // if true, it capture browsers, run tests and exit
-        singleRun: true
+        browsers: ['PhantomJS']
     });
 };


### PR DESCRIPTION
Instead of:
- Skipped tests
- Passing tests
- Complaints about Piwik already being registered

Why:
- Easier to debug failing tests